### PR TITLE
Eu corrigi from speechbrain.inference.VAD import VAD

### DIFF
--- a/data_loaders/gesture/scripts/genea_prep_vad.py
+++ b/data_loaders/gesture/scripts/genea_prep_vad.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser
 import os
 import numpy as np
 import torch
-from speechbrain.pretrained import VAD
+from speechbrain.inference.VAD import VAD
 import torchaudio
 from scipy.signal import resample
 from tqdm import tqdm


### PR DESCRIPTION
Eu fiz uma mudanza de 'from speechbrain.pretrained import VAD' porque ta deprecated e mude ao 'from speechbrain.inference.VAD import VAD' no path 'data_loaders/gesture/scripts/genea_prep_vad.py'